### PR TITLE
requirements: Fix crash due to misaligned VkPhysicalDeviceFeatures

### DIFF
--- a/vkrunner/requirements.rs
+++ b/vkrunner/requirements.rs
@@ -79,6 +79,7 @@ struct LazyStructures {
 }
 
 // Lazily generated VkPhysicalDeviceFeatures struct to pass to Vulkan
+#[repr(align(4))]
 struct LazyBaseFeatures {
     // Array big enough to store a VkPhysicalDeciveFeatures struct.
     // It’s easier to manipulate as an array instead of the actual


### PR DESCRIPTION
Ensure that the struct (hence the its first and only element) that holds our byte array that represents VkPhysicalDeviceFeatures is pointer aligned.

Fixes the following crash when running vkrunner:

    thread 'main' panicked at 'misaligned pointer dereference: address must be a multiple of 0x4
    but is 0x7ffddd850925', vkrunner/libvkrunner.rlib.p/structured/requirements.rs:435:13